### PR TITLE
Show noise posts by default in moderator mode

### DIFF
--- a/src/app/components/ArgumentCard.tsx
+++ b/src/app/components/ArgumentCard.tsx
@@ -344,7 +344,7 @@ export default function ArgumentCard({
     const [argumentRemoved, setArgumentRemoved] = useState(!!argument.isRemoved);
     const [moderatorOverrides, setModeratorOverrides] = useState<Record<string, boolean>>({});
     const [moderatorUpdatingId, setModeratorUpdatingId] = useState<string | null>(null);
-    const [showNoiseComments, setShowNoiseComments] = useState(false);
+    const [showNoiseComments, setShowNoiseComments] = useState(moderatorMode);
 
     const addOptimisticComment = (comment: TopicApiResponse["arguments"][number]["comments"][number]) => {
         setCommentStates((prev) => [...prev, { ...comment, pending: true } as any]);
@@ -375,6 +375,10 @@ export default function ArgumentCard({
         setArgumentVisibility(argument.visibility);
         setArgumentRemoved(!!argument.isRemoved);
     }, [argument.visibility, argument.isRemoved]);
+
+    useEffect(() => {
+        setShowNoiseComments(moderatorMode);
+    }, [moderatorMode]);
 
     useEffect(() => {
         if (typeof window === "undefined") return;

--- a/src/app/components/topics/TopicArgumentList.tsx
+++ b/src/app/components/topics/TopicArgumentList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
 import ArgumentCard from "@/app/components/ArgumentCard";
 import { TopicApiResponse } from "@/app/types/topicApiResponse";
@@ -18,7 +18,11 @@ export default function TopicArgumentList({
 }) {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id || viewerId;
-  const [showNoise, setShowNoise] = useState(false);
+  const [showNoise, setShowNoise] = useState(moderatorMode);
+
+  useEffect(() => {
+    setShowNoise(moderatorMode);
+  }, [moderatorMode]);
 
   const { visibleArguments, noiseArguments } = useMemo(() => {
     if (moderatorMode) {
@@ -63,8 +67,8 @@ export default function TopicArgumentList({
             <button
               type="button"
               className="btn btn-outline-secondary btn-sm"
-            onClick={() => setShowNoise(true)}
-          >
+              onClick={() => setShowNoise(true)}
+            >
               {`View more posts (${hiddenNoiseCount})`}
             </button>
           </div>


### PR DESCRIPTION
### Motivation
- Moderators should immediately see content flagged as noise when they enable moderator mode so they can review and act on hidden posts and replies without extra toggles.

### Description
- Default `showNoise` in `src/app/components/topics/TopicArgumentList.tsx` and `showNoiseComments` in `src/app/components/ArgumentCard.tsx` to the `moderatorMode` value and add `useEffect` hooks to keep those flags in sync when `moderatorMode` changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809e156c10832d8bd21563992ff8fe)